### PR TITLE
Add postLayouts API UT

### DIFF
--- a/src/controller/layoutController.ts
+++ b/src/controller/layoutController.ts
@@ -124,7 +124,7 @@ const buildSql = (conditions: Map<string, any>): string => {
 };
 
 const convertProtocol = (layouts: Layout[]): GetLayoutResponse => {
-    if (Layout.length === 0) {
+    if (layouts.length === 0) {
         return null;
     }
 

--- a/src/dbutil/connectionWrapper.ts
+++ b/src/dbutil/connectionWrapper.ts
@@ -1,5 +1,7 @@
 import { promisify } from "util";
 
+import { Logger } from "../logger/logger";
+
 export class ConnectionWrapper {
     private readonly connection;
 
@@ -17,10 +19,12 @@ export class ConnectionWrapper {
 
     public async commit(): Promise<void> {
         promisify(this.connection.conn.commit).bind(this.connection.conn)();
+        Logger.getLogger().info(`Commit connection=${this.connection.uuid}`);
     }
 
     public async rollback(): Promise<void> {
         promisify(this.connection.conn.rollback).bind(this.connection.conn)();
+        Logger.getLogger().info(`Rollback connection=${this.connection.uuid}`);
     }
 
     public async setAutoCommit(autoCommit: boolean): Promise<void> {

--- a/test/controller/layoutController.spec.ts
+++ b/test/controller/layoutController.spec.ts
@@ -1,0 +1,265 @@
+import * as config from "config";
+
+import { getLayouts, postLayouts } from "../../src/controller/layoutController";
+import { ConnectionWrapper } from "../../src/dbutil/connectionWrapper";
+import { DBConnectionManager } from "../../src/dbutil/dbConnectionManager";
+import { DBQueryRunner } from "../../src/dbutil/dbQueryRunner";
+import { Layout } from "../../src/entity/layout";
+import { PostLayoutRequest } from "../../src/protocol/layoutProtocol";
+import { mockGetRequest, mockPostRequest, mockResponse } from "../mockRequestResponse";
+
+const dbConfig: any = config.get(`jdbcConfig.dbConfig.default`);
+const connManager: DBConnectionManager = DBConnectionManager.getInstance();
+let connection: ConnectionWrapper = null;
+let dbQueryRunner: DBQueryRunner = null;
+
+beforeAll(async () => {
+    await connManager.initialize(dbConfig);
+    connection = await connManager.getConnection();
+
+    dbQueryRunner = new DBQueryRunner(connection);
+    const sql: string =
+        "CREATE TABLE IF NOT EXISTS Layout (" +
+        "  id           int NOT NULL AUTO_INCREMENT," +
+        "  owner        varchar(8) NOT NULL," +
+        "  name         varchar(50) NOT NULL," +
+        "  version      int NOT NULL," +
+        "  belonging    varchar(20) NOT NULL," +
+        "  shareWith    varchar(5) NOT NULL," +
+        "  layout       text NOT NULL," +
+        "  saveDateTime datetime NOT NULL," +
+        "  PRIMARY KEY(id)" +
+        ")";
+    await dbQueryRunner.update(sql);
+    await connection.commit();
+});
+afterAll(async () => {
+    // const sql: string = "DROP TABLE IF EXISTS Layout";
+    // await dbQueryRunner.update(sql);
+    // await connection.commit();
+    await connManager.releaseConnection(connection);
+});
+
+describe("postLayouts", () => {
+    beforeEach(async () => {
+        await dbQueryRunner.update("DELETE FROM Layout");
+        await connection.commit();
+    });
+
+    it("should register one record into database if request layout is one", async () => {
+        const layoutReq: PostLayoutRequest = {
+            owner: "owner1",
+            group: "group1",
+            layouts: [
+                {
+                    id: null,
+                    name: "layoutName1",
+                    shareWith: "None",
+                    layout: "layout1",
+                },
+            ],
+        };
+        const req: any = mockPostRequest(layoutReq);
+        const res: any = mockResponse();
+
+        await postLayouts(req, res, () => { });
+        expect(res.json).toHaveBeenCalledWith({ result: "success" });
+
+        const results: Layout[] = await dbQueryRunner.query("SELECT * FROM Layout");
+        expect(results.length).toBe(1);
+        expect(results).toEqual([
+            {
+                id: expect.anything(),
+                owner: layoutReq.owner,
+                name: layoutReq.layouts[0].name,
+                version: 1,
+                belonging: layoutReq.group,
+                shareWith: layoutReq.layouts[0].shareWith,
+                layout: `\"${layoutReq.layouts[0].layout}\"`,
+                saveDateTime: expect.anything(),
+            },
+        ]);
+    });
+
+    it("should register specified records into database if request layout is multiples", async () => {
+        const layoutReq: PostLayoutRequest = {
+            owner: "owner2",
+            group: "group1",
+            layouts: [
+                {
+                    id: null,
+                    name: "layoutName2",
+                    shareWith: "None",
+                    layout: "layout2",
+                },
+                {
+                    id: null,
+                    name: "layoutName3",
+                    shareWith: "All",
+                    layout: "layout3",
+                },
+                {
+                    id: null,
+                    name: "layoutName4",
+                    shareWith: "Group",
+                    layout: "layout4",
+                },
+            ],
+        };
+        const req: any = mockPostRequest(layoutReq);
+        const res: any = mockResponse();
+
+        await postLayouts(req, res, () => { });
+        expect(res.json).toHaveBeenCalledWith({ result: "success" });
+
+        const results: Layout[] = await dbQueryRunner.query(`SELECT * FROM Layout`);
+        expect(results.length).toBe(3);
+        expect(results).toEqual([
+            {
+                id: expect.anything(),
+                owner: layoutReq.owner,
+                name: layoutReq.layouts[0].name,
+                version: 1,
+                belonging: layoutReq.group,
+                shareWith: layoutReq.layouts[0].shareWith,
+                layout: `\"${layoutReq.layouts[0].layout}\"`,
+                saveDateTime: expect.anything(),
+            },
+            {
+                id: expect.anything(),
+                owner: layoutReq.owner,
+                name: layoutReq.layouts[1].name,
+                version: 1,
+                belonging: layoutReq.group,
+                shareWith: layoutReq.layouts[1].shareWith,
+                layout: `\"${layoutReq.layouts[1].layout}\"`,
+                saveDateTime: expect.anything(),
+            },
+            {
+                id: expect.anything(),
+                owner: layoutReq.owner,
+                name: layoutReq.layouts[2].name,
+                version: 1,
+                belonging: layoutReq.group,
+                shareWith: layoutReq.layouts[2].shareWith,
+                layout: `\"${layoutReq.layouts[2].layout}\"`,
+                saveDateTime: expect.anything(),
+            },
+        ]);
+    });
+
+    it("should register new record into database if request is update", async () => {
+        const layoutReq: PostLayoutRequest = {
+            owner: "owner1",
+            group: "group1",
+            layouts: [
+                {
+                    id: null,
+                    name: "layoutName1",
+                    shareWith: "None",
+                    layout: "layout1",
+                },
+            ],
+        };
+        const req: any = mockPostRequest(layoutReq);
+        const res: any = mockResponse();
+
+        await postLayouts(req, res, () => { });
+        expect(res.json).toHaveBeenCalledWith({ result: "success" });
+
+        const results: Layout[] = await dbQueryRunner.query("SELECT * FROM Layout");
+        expect(results.length).toBe(1);
+        expect(results).toEqual([
+            {
+                id: expect.anything(),
+                owner: layoutReq.owner,
+                name: layoutReq.layouts[0].name,
+                version: 1,
+                belonging: layoutReq.group,
+                shareWith: layoutReq.layouts[0].shareWith,
+                layout: `\"${layoutReq.layouts[0].layout}\"`,
+                saveDateTime: expect.anything(),
+            },
+        ]);
+
+        await connection.commit();
+
+        const updateLayoutReq: PostLayoutRequest = {
+            owner: "owner1",
+            group: "group1",
+            layouts: [
+                {
+                    id: results[0].id,
+                    name: "UpdatedLayoutName1",
+                    shareWith: "All",
+                    layout: "UpdatedLayout1",
+                },
+            ],
+        };
+        const updatedReq: any = mockPostRequest(updateLayoutReq);
+        const updatedRes: any = mockResponse();
+        await postLayouts(updatedReq, updatedRes, () => { });
+        expect(updatedRes.json).toHaveBeenCalledWith({ result: "success" });
+
+        const results2: Layout[] = await dbQueryRunner.query("SELECT * FROM Layout");
+        expect(results2.length).toBe(2);
+        expect(results2).toEqual([
+            {
+                id: expect.anything(),
+                owner: layoutReq.owner,
+                name: layoutReq.layouts[0].name,
+                version: 1,
+                belonging: layoutReq.group,
+                shareWith: layoutReq.layouts[0].shareWith,
+                layout: `\"${layoutReq.layouts[0].layout}\"`,
+                saveDateTime: expect.anything(),
+            },
+            {
+                id: expect.anything(),
+                owner: updateLayoutReq.owner,
+                name: updateLayoutReq.layouts[0].name,
+                version: 2,
+                belonging: updateLayoutReq.group,
+                shareWith: updateLayoutReq.layouts[0].shareWith,
+                layout: `\"${updateLayoutReq.layouts[0].layout}\"`,
+                saveDateTime: expect.anything(),
+            },
+        ]);
+    });
+
+    it("should rollback database and throw error if request includes illegal parameters", async () => {
+        const layoutReq: PostLayoutRequest = {
+            owner: "owner2",
+            group: "group1",
+            layouts: [
+                {
+                    id: null,
+                    name: "layoutName2",
+                    shareWith: "None",
+                    layout: "layout2",
+                },
+                {
+                    id: null,
+                    name: "layoutName3",
+                    shareWith: "All",
+                    layout: "layout3",
+                },
+                {
+                    id: undefined,
+                    name: "layoutName4",
+                    shareWith: "OverflowString" as any,
+                    layout: 1,
+                },
+            ],
+        };
+        const req: any = mockPostRequest(layoutReq);
+        const res: any = mockResponse();
+
+        const postLayoutsPromise = postLayouts(req, res, () => { });
+        await expect(postLayoutsPromise).rejects.toThrow();
+
+        const results: Layout[] = await dbQueryRunner.query(`SELECT * FROM Layout`);
+        expect(results.length).toBe(0);
+        expect(results).toEqual([]);
+    });
+});


### PR DESCRIPTION
- POST /layout APIのUT追加
- GET /layout APIの結果が0件の場合の判定誤りを修正
- ConnectionWrapperのcommitとrollbackにログを追加